### PR TITLE
Add k-d tree NMS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ python3 evaluation/compute_iou.py prediction.mrc label.mrc --radius 1
 ```
 This script prints the IoU score for each class as well as the average IoU.
 
+## Clustering Predictions
+The script [utils/cluster_cn_predicted_map.py](utils/cluster_cn_predicted_map.py)
+clusters predicted atom locations into a labeled MRC map. When ``--nms_radius``
+is greater than zero, the program performs non-maximum suppression. The
+``--nms_method`` option chooses between the basic algorithm and a faster
+KD-tree implementation:
+
+```bash
+python3 utils/cluster_cn_predicted_map.py prob.txt map.mrc out.mrc \
+    --nms_radius 1.5 --nms_method kdtree
+```
+
 
 
 


### PR DESCRIPTION
## Summary
- implement `nms_kdtree` and optional NMS radius in `cluster_cn_predicted_map.py`
- expose `--nms_method` and `--nms_radius` CLI options
- document clustering options in README

## Testing
- `python3 -m py_compile utils/cluster_cn_predicted_map.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d1507ac688330b65d65d6afe1b35c